### PR TITLE
Added functionality to all buttons

### DIFF
--- a/src/assets/emojis.ts
+++ b/src/assets/emojis.ts
@@ -247,5 +247,3 @@ export const getCategory = (category: keyof AllEmojis) => {
   const validEmojis = emojis[category]
   return validEmojis;
 }
-
-// export { emojis as default }

--- a/src/assets/emojis.ts
+++ b/src/assets/emojis.ts
@@ -1,7 +1,7 @@
 import { AllEmojis } from "@/assets/interfaces";
 
 // Coomented-out emojis were added post 2018 and will not
-// properly render on outdate but fairly new devices
+// properly render on outdated but fairly new devices
 const emojis: AllEmojis = {
   "hearts": [
     ["0x2764", "Red heart"],

--- a/src/assets/interfaces.ts
+++ b/src/assets/interfaces.ts
@@ -8,7 +8,6 @@ export interface AllEmojis {
 }
 
 export interface ActiveEmoji {
-  position: number,
   codepoint: string,
   label: string,
   category: string

--- a/src/components/AddEmoji.vue
+++ b/src/components/AddEmoji.vue
@@ -2,12 +2,12 @@
   <div>
     <p>Add an emoji!</p>
     <div class="button-wrapper">
-      <button @click="addEvent('heart')">Add heart</button>
-      <button @click="addEvent('flower')">Add flower</button>
-      <button @click="addEvent('fruit')">Add fruit</button>
-      <button @click="addEvent('animal')">Add animal</button>
-      <button @click="addEvent('food')">Add food</button>
-      <button @click="addEvent('astra')">Add astra</button>
+      <button @click="addEmoji('hearts')">Add heart &#128149;</button>
+      <button @click="addEmoji('flowers')">Add flower &#127801;</button>
+      <button @click="addEmoji('fruits')">Add fruit &#127817;</button>
+      <button @click="addEmoji('animals')">Add animal &#128049;</button>
+      <button @click="addEmoji('food')">Add food &#129360;</button>
+      <button @click="addEmoji('astra')">Add astra &#127776;</button>
     </div>
   </div>
 </template>
@@ -18,11 +18,11 @@ import { defineComponent } from "vue";
 export default defineComponent({
   name: "AddEmoji",
   methods: {
-    addEvent(type: string) {
-      return console.log("Emitting add event for: ", type)
+    addEmoji(type: string) {
+      this.$emit("add-emoji", type);
     }
   }
-})
+});
 </script>
 
 <style scoped>

--- a/src/components/AddEmoji.vue
+++ b/src/components/AddEmoji.vue
@@ -1,12 +1,14 @@
 <template>
-  <div class="button-wrapper">
+  <div>
     <p>Add an emoji!</p>
-    <button @click="addEvent('heart')">Add heart</button>
-    <button @click="addEvent('flower')">Add flower</button>
-    <button @click="addEvent('fruit')">Add fruit</button>
-    <button @click="addEvent('animal')">Add animal</button>
-    <button @click="addEvent('food')">Add food</button>
-    <button @click="addEvent('astra')">Add astra</button>
+    <div class="button-wrapper">
+      <button @click="addEvent('heart')">Add heart</button>
+      <button @click="addEvent('flower')">Add flower</button>
+      <button @click="addEvent('fruit')">Add fruit</button>
+      <button @click="addEvent('animal')">Add animal</button>
+      <button @click="addEvent('food')">Add food</button>
+      <button @click="addEvent('astra')">Add astra</button>
+    </div>
   </div>
 </template>
 
@@ -25,10 +27,15 @@ export default defineComponent({
 
 <style scoped>
 .button-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  flex-wrap: wrap;
+  border: 1px dashed black;
   font-size: 1rem !important;
 }
 button {
-  width: 95%;
-  margin: 0;
+  min-width: 10rem;
+  margin: 2px;
 }
 </style>

--- a/src/components/Emoji.vue
+++ b/src/components/Emoji.vue
@@ -23,9 +23,12 @@ export default defineComponent({
     category: {
       type: String,
       required: true
-    },
+    }
   },
-})
+  setup(props) {
+    console.log("from child", props.position);
+  }
+});
 </script>
 
 <style scoped>

--- a/src/components/Emoji.vue
+++ b/src/components/Emoji.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    console.log("from child", props.position);
+    console.log("Child in index", props.position);
   }
 });
 </script>

--- a/src/store/methods.ts
+++ b/src/store/methods.ts
@@ -1,5 +1,5 @@
 import { getCategory } from "@/assets/emojis";
-import { AllEmojis } from "@/assets/interfaces";
+import { ActiveEmoji, AllEmojis } from "@/assets/interfaces";
 import { getRandomInt } from "@/utils/randomInt";
 import state from "./state";
 
@@ -7,59 +7,41 @@ export function setDefault() {
   state.message = "Welcome";
   state.emojis.clear();
   state.emojis.set(0, {
-    position: 0,
     codepoint: "0x1F493",
     label: "Beating heart",
     category: "hearts"
   });
   state.emojis.set(1, {
-    position: 1,
     codepoint: "0x1F490",
     label: "Bouquet",
     category: "flowers"
   });
   state.emojis.set(2, {
-    position: 2,
     codepoint: "0x1F352",
     label: "Cherries",
     category: "fruits"
   });
   state.emojis.set(3, {
-    position: 3,
     codepoint: "0x1F30C",
     label: "Milky way",
     category: "astra"
   });
-  // state.emojis.set(1, ["0x1F49A", "Green heart"]);
-  // state.emojis.set(2, ["0x1F48C", "Heart envelope"]);
-  // state.emojis.set(3, ["0x1F49D", "Heart with ribbon"]);
-  console.log("Default set.");
 }
 
-export function shiftEmoji(
-  id: number,
-  position: number,
-  category: keyof AllEmojis
-) {
+export function setEmoji(position: number, emojiData: ActiveEmoji) {
+  state.emojis.set(position, emojiData);
+}
+
+export function shiftEmoji(position: number, category: keyof AllEmojis) {
   const validEmojis = getCategory(category);
   const index = getRandomInt(0, validEmojis.length);
   const newEmoji = validEmojis[index];
   console.log("newEmoji: ", newEmoji);
-  state.emojis.set(id, {
-    position: position,
+
+  setEmoji(position, {
     codepoint: newEmoji[0],
     label: newEmoji[1],
     category: category
   });
   console.log(state.emojis);
 }
-
-// export function getEmojiArray() {
-//   const emojiArray: [number, number, string] = [];
-//   state.emojis.forEach((emoji: [number, string], position: number) => {
-//     emojiArray.push(position, ...emoji);
-//   });
-//   console.log(emojiArray);
-
-//   return emojiArray;
-// }

--- a/src/store/methods.ts
+++ b/src/store/methods.ts
@@ -45,3 +45,15 @@ export function shiftEmoji(position: number, category: keyof AllEmojis) {
   });
   console.log(state.emojis);
 }
+
+export function removeEmoji(position: number) {
+  for (const key of state.emojis.keys()) {
+    if (key > position) {
+      const emojiData: ActiveEmoji | undefined = state.emojis.get(key);
+      if (emojiData != undefined) {
+        setEmoji(key - 1, emojiData);
+      }
+    }
+  }
+  state.emojis.delete(state.emojis.size - 1);
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -33,7 +33,7 @@
 import { defineComponent, onMounted } from "vue";
 
 import state from "@/store/state";
-import { setDefault, shiftEmoji } from "@/store/methods";
+import { setDefault, setEmoji, shiftEmoji } from "@/store/methods";
 import { AllEmojis, ActiveEmoji } from "@/assets/interfaces";
 
 import Message from "@/components/Message.vue";
@@ -60,32 +60,43 @@ export default defineComponent({
       console.log(state.emojis);
     });
 
-    // const lastPosition = ref(state.emojis.size);
-
-    // function updateLastPosition() {
-    //   lastPosition.value++;
-    //   console.log(lastPosition.value);
-    // }
-
     function newEmoji(emojiType: keyof AllEmojis) {
       console.log(emojiType);
-      shiftEmoji(state.emojis.size + 1, emojiType);
+      shiftEmoji(state.emojis.size, emojiType);
     }
 
     function moveLeft(position: number) {
       console.log("Moving left from position", position);
-      if (position > 1) {
+      if (position > 0) {
         const currentEmoji: ActiveEmoji | undefined = state.emojis.get(
           position
         );
         const leftEmoji: ActiveEmoji | undefined = state.emojis.get(
           position - 1
         );
+
+        if (currentEmoji != undefined && leftEmoji != undefined) {
+          setEmoji(position - 1, currentEmoji);
+          setEmoji(position, leftEmoji);
+        }
       }
     }
 
     function moveRight(position: number) {
       console.log("Moving right from position", position);
+      if (position < state.emojis.size) {
+        const currentEmoji: ActiveEmoji | undefined = state.emojis.get(
+          position
+        );
+        const rightEmoji: ActiveEmoji | undefined = state.emojis.get(
+          position + 1
+        );
+
+        if (currentEmoji != undefined && rightEmoji != undefined) {
+          setEmoji(position + 1, currentEmoji);
+          setEmoji(position, rightEmoji);
+        }
+      }
     }
 
     return { shiftEmoji, newEmoji, moveLeft, moveRight };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -18,13 +18,15 @@
           <button @click="shiftEmoji(position, emojiData.category)">
             Shift
           </button>
-          <button>Remove</button>
+          <button @click="removeEmoji(position)">Remove</button>
           <button @click="moveLeft(position)">&#60;</button>
           <span style="font-size: 0.9rem;">Move</span>
           <button @click="moveRight(position)">&#62;</button>
         </div>
       </div>
     </div>
+    <button @click="setDefault()">Start over</button>
+    <button @click="state.emojis.clear()">Clear all</button>
     <AddEmoji @add-emoji="newEmoji($event)" />
   </div>
 </template>
@@ -33,7 +35,7 @@
 import { defineComponent, onMounted } from "vue";
 
 import state from "@/store/state";
-import { setDefault, setEmoji, shiftEmoji } from "@/store/methods";
+import { setDefault, setEmoji, shiftEmoji, removeEmoji } from "@/store/methods";
 import { AllEmojis, ActiveEmoji } from "@/assets/interfaces";
 
 import Message from "@/components/Message.vue";
@@ -99,7 +101,14 @@ export default defineComponent({
       }
     }
 
-    return { shiftEmoji, newEmoji, moveLeft, moveRight };
+    return {
+      shiftEmoji,
+      newEmoji,
+      removeEmoji,
+      setDefault,
+      moveLeft,
+      moveRight
+    };
   }
 });
 </script>
@@ -132,7 +141,7 @@ export default defineComponent({
   flex-direction: row;
   justify-content: space-between;
 }
-.button-wrapper button {
+button {
   margin: 0 2px 0 2px;
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="home">
     <Message :msg="state.message" />
-    <div class="upper-wrapper">
+    <div class="emoji-box-wrapper">
       <div
         class="emoji-wrapper"
         v-for="[id, emojiData] in state.emojis.entries()"
@@ -46,10 +46,8 @@
         <Emoji class="emoji-box" />
         <button>Shift</button>
       </div> -->
-      <div class="emoji-wrapper">
-        <AddEmoji class="emoji-box" />
-      </div>
     </div>
+    <AddEmoji />
   </div>
 </template>
 
@@ -89,9 +87,10 @@ export default defineComponent({
 .home {
   border: 1px solid black;
 }
-.upper-wrapper {
+.emoji-box-wrapper {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
 }
 .emoji-wrapper {
   display: flex;
@@ -108,6 +107,9 @@ export default defineComponent({
   font-size: 9.5rem;
   border: 1px dashed black;
 }
+/* .add-buttons-wrapper {
+
+} */
 .button-wrapper {
   flex-direction: row;
   justify-content: space-between;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,59 +4,38 @@
     <div class="emoji-box-wrapper">
       <div
         class="emoji-wrapper"
-        v-for="[id, emojiData] in state.emojis.entries()"
-        :key="id"
+        v-for="[position, emojiData] in state.emojis.entries()"
+        :key="position"
       >
         <Emoji
           class="emoji-box"
-          :position="emojiData.position"
+          :position="position"
           :codepoint="emojiData.codepoint"
           :label="emojiData.label"
           :category="emojiData.category"
         />
         <div class="button-wrapper">
-          <button @click="shiftEmoji(id, emojiData.position, emojiData.category)">Shift</button>
+          <button @click="shiftEmoji(position, emojiData.category)">
+            Shift
+          </button>
           <button>Remove</button>
-          <button>&#60;</button>
+          <button @click="moveLeft(position)">&#60;</button>
           <span style="font-size: 0.9rem;">Move</span>
-          <button>&#62;</button>
+          <button @click="moveRight(position)">&#62;</button>
         </div>
       </div>
-      <!-- <div class="emoji-wrapper">
-        <Emoji class="emoji-box" />
-        <button>Shift</button>
-      </div>
-      <div class="emoji-wrapper">
-        <Emoji class="emoji-box" />
-        <button>Shift</button>
-      </div>
-      <div class="emoji-wrapper">
-        <Emoji class="emoji-box" />
-        <button>Shift</button>
-      </div>
-      <div class="emoji-wrapper">
-        <Emoji class="emoji-box" />
-        <button>Shift</button>
-      </div>
-      <div class="emoji-wrapper">
-        <Emoji class="emoji-box" />
-        <button>Shift</button>
-      </div>
-      <div class="emoji-wrapper">
-        <Emoji class="emoji-box" />
-        <button>Shift</button>
-      </div> -->
     </div>
-    <AddEmoji />
+    <AddEmoji @add-emoji="newEmoji($event)" />
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
-import { AllEmojis } from "@/assets/interfaces";
-import { getCategory } from "@/assets/emojis";
+import { defineComponent, onMounted } from "vue";
+
 import state from "@/store/state";
 import { setDefault, shiftEmoji } from "@/store/methods";
+import { AllEmojis, ActiveEmoji } from "@/assets/interfaces";
+
 import Message from "@/components/Message.vue";
 import Emoji from "@/components/Emoji.vue";
 import AddEmoji from "@/components/AddEmoji.vue";
@@ -74,11 +53,42 @@ export default defineComponent({
     };
   },
   setup() {
-    if (state.emojis.size === 0) {
-      setDefault();
+    onMounted(() => {
+      if (state.emojis.size === 0) {
+        setDefault();
+      }
+      console.log(state.emojis);
+    });
+
+    // const lastPosition = ref(state.emojis.size);
+
+    // function updateLastPosition() {
+    //   lastPosition.value++;
+    //   console.log(lastPosition.value);
+    // }
+
+    function newEmoji(emojiType: keyof AllEmojis) {
+      console.log(emojiType);
+      shiftEmoji(state.emojis.size + 1, emojiType);
     }
-    console.log(state.emojis);
-    return { shiftEmoji }
+
+    function moveLeft(position: number) {
+      console.log("Moving left from position", position);
+      if (position > 1) {
+        const currentEmoji: ActiveEmoji | undefined = state.emojis.get(
+          position
+        );
+        const leftEmoji: ActiveEmoji | undefined = state.emojis.get(
+          position - 1
+        );
+      }
+    }
+
+    function moveRight(position: number) {
+      console.log("Moving right from position", position);
+    }
+
+    return { shiftEmoji, newEmoji, moveLeft, moveRight };
   }
 });
 </script>
@@ -107,9 +117,6 @@ export default defineComponent({
   font-size: 9.5rem;
   border: 1px dashed black;
 }
-/* .add-buttons-wrapper {
-
-} */
 .button-wrapper {
   flex-direction: row;
   justify-content: space-between;


### PR DESCRIPTION
Added working logic for the `Shift`, `Remove`, `Move left` and `Move right` buttons. Also added a `Start over` and a `Clear all` button, which restores the state to the current backend default, and clears all emojis from the state, respectively.

The state structure was modified to implement this logic, removing the `position` property from the `activeEmoji` data. Current methods for state handling will consider the emoji map's keys as their position instead. Keys therefore should always be consecutive positive integers starting at 0. Keys are updated upon removing emojis, preserving the integer sequence. This implementation may change in the future.